### PR TITLE
Parsing of date strings is strongly discouraged due to browser differences and inconsistencies

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,8 +6,11 @@ window.onload = function onLoad() {
 
   function progress() {
     var now = new Date();
-    var start = new Date("2010-07-03");
-    var end = new Date("2020-01-01 23:59:59");
+    // 2010-07-03
+    var start = new Date(Date.UTC(2010, 6, 3));
+    // 2020-01-01 23:59:59
+    var end = new Date(Date.UTC(2020, 0, 1, 23, 59, 59));
+    console.log(end)
     var done = (now-start) / (end-start);
     document.getElementById("percent").innerHTML = done*100 + "%";
     return done;


### PR DESCRIPTION
Further to #1, MDN web docs warns:

> **Note:** parsing of date strings with the `Date` constructor (and `Date.parse`, they are equivalent) is strongly discouraged due to browser differences and inconsistencies. Support for RFC 2822 format strings is by convention only. Support for ISO 8601 formats differs in that date-only strings (e.g. "1970-01-01") are treated as UTC, not local.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date

Instead, use explicit `year`, `monthIndex`, `day`, `hours`, `minutes` and `seconds` arguments.